### PR TITLE
Add `ignore_patterns` arg for ignoring layers

### DIFF
--- a/auto_fp8/__init__.py
+++ b/auto_fp8/__init__.py
@@ -1,5 +1,5 @@
-from .modeling import AutoFP8ForCausalLM
 from .config import BaseQuantizeConfig
+from .modeling import AutoFP8ForCausalLM
 
 __all__ = [
     "AutoFP8ForCausalLM",

--- a/auto_fp8/config.py
+++ b/auto_fp8/config.py
@@ -1,5 +1,13 @@
+from typing import List
+
+
 class BaseQuantizeConfig:
-    def __init__(self, quant_method="fp8", activation_scheme="static"):
+    def __init__(
+        self,
+        quant_method: str = "fp8",
+        activation_scheme: str = "static",
+        ignore_patterns: List[str] = [],
+    ):
         if quant_method != "fp8":
             raise ValueError("Only FP8 quantization is supported.")
         if activation_scheme not in ["static", "dynamic"]:
@@ -8,3 +16,5 @@ class BaseQuantizeConfig:
             )
         self.quant_method = quant_method
         self.activation_scheme = activation_scheme
+        self.ignore_patterns = ignore_patterns
+        self.ignored_layers = []

--- a/auto_fp8/modeling.py
+++ b/auto_fp8/modeling.py
@@ -140,8 +140,6 @@ def get_layers_to_ignore(model, ignore_patterns) -> List[str]:
             if ignore_pattern.startswith(regex_prefix):
                 # check if name matches regex and add to set if true
                 regex_pattern = ignore_pattern[len(regex_prefix) :]
-                print(regex_pattern)
-                print(name)
                 if re.search(regex_pattern, name):
                     ignored_layers.add(name)
             else:

--- a/auto_fp8/modeling.py
+++ b/auto_fp8/modeling.py
@@ -1,23 +1,33 @@
+import re
+from typing import List
+
 import torch
-from transformers import AutoModelForCausalLM, PreTrainedModel
+from transformers import AutoModelForCausalLM
+
+from auto_fp8.config import BaseQuantizeConfig
 from auto_fp8.quantize import (
-    quantize_weights,
     quantize_activations,
+    quantize_weights,
     save_quantized_model,
 )
-from auto_fp8.config import BaseQuantizeConfig
 
 
 class AutoFP8ForCausalLM:
     def __init__(
         self,
-        model: PreTrainedModel,
+        model: AutoModelForCausalLM,
         quantize_config: BaseQuantizeConfig,
     ):
         self.model = model
         self.model_type = self.model.config.model_type
-        self.quantize_config = quantize_config
         self.config = self.model.config
+
+        # Gather the Linear module names that we want to ignore
+        quantize_config.ignored_layers = get_layers_to_ignore(
+            self.model, quantize_config.ignore_patterns
+        )
+
+        self.quantize_config = quantize_config
 
     @classmethod
     def from_pretrained(
@@ -94,16 +104,49 @@ class AutoFP8ForCausalLM:
             return calibration_tokens
 
         # Always quantize the weights as they do not require calibration data
-        quantize_weights(self.model)
+        quantize_weights(self.model, self.quantize_config)
 
         if self.quantize_config.activation_scheme == "static":
             quantize_activations(
-                self.model, _prepare_calibration_data(calibration_tokens)
+                self.model,
+                self.quantize_config,
+                _prepare_calibration_data(calibration_tokens),
             )
+
+            # import copy
+            # for layer in self.model.model.layers:
+            #     layer.self_attn.kv_scale = copy.deepcopy(layer.self_attn.k_proj.act_scale)
 
     def save_quantized(self, save_dir):
         save_quantized_model(
             self.model,
-            activation_scheme=self.quantize_config.activation_scheme,
+            quant_config=self.quantize_config,
             save_dir=save_dir,
         )
+
+
+def get_layers_to_ignore(model, ignore_patterns) -> List[str]:
+    ignored_layers = set()
+
+    # TODO: don't always ignore lm_head
+    ignore_patterns.append("re:.*lm_head")
+
+    for name, linear in model.named_modules():
+        if not isinstance(linear, torch.nn.Linear):
+            continue
+
+        for ignore_pattern in ignore_patterns:
+            regex_prefix = "re:"
+            if ignore_pattern.startswith(regex_prefix):
+                # check if name matches regex and add to set if true
+                regex_pattern = ignore_pattern[len(regex_prefix) :]
+                print(regex_pattern)
+                print(name)
+                if re.search(regex_pattern, name):
+                    ignored_layers.add(name)
+            else:
+                # else, exact match
+                if ignore_pattern == name:
+                    ignored_layers.add(name)
+
+    return list(ignored_layers)

--- a/example.py
+++ b/example.py
@@ -1,4 +1,5 @@
 from transformers import AutoTokenizer
+
 from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
 pretrained_model_dir = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -8,9 +9,13 @@ tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
 examples = ["auto_fp8 is an easy-to-use model quantization library"]
 examples = tokenizer(examples, return_tensors="pt").to("cuda")
 
+ignore_patterns = ["re:.*gate"]
+
 quantize_config = BaseQuantizeConfig(
-    quant_method="fp8", activation_scheme="dynamic"
-)  # or "static"
+    quant_method="fp8",
+    activation_scheme="dynamic",  # or "static"
+    ignore_patterns=ignore_patterns,
+)
 
 model = AutoFP8ForCausalLM.from_pretrained(
     pretrained_model_dir, quantize_config=quantize_config

--- a/example.py
+++ b/example.py
@@ -9,12 +9,10 @@ tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
 examples = ["auto_fp8 is an easy-to-use model quantization library"]
 examples = tokenizer(examples, return_tensors="pt").to("cuda")
 
-ignore_patterns = ["re:.*gate"]
-
 quantize_config = BaseQuantizeConfig(
     quant_method="fp8",
     activation_scheme="dynamic",  # or "static"
-    ignore_patterns=ignore_patterns,
+    ignore_patterns=["re:.*lm_head"],
 )
 
 model = AutoFP8ForCausalLM.from_pretrained(

--- a/example_dataset.py
+++ b/example_dataset.py
@@ -7,6 +7,8 @@ pretrained_model_dir = "meta-llama/Meta-Llama-3-8B-Instruct"
 quantized_model_dir = "Meta-Llama-3-8B-Instruct-FP8"
 
 tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
+tokenizer.pad_token = tokenizer.eos_token
+
 ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(512)
 examples = [tokenizer.apply_chat_template(batch["messages"], tokenize=False) for batch in ds]
 examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to("cuda")

--- a/example_dataset.py
+++ b/example_dataset.py
@@ -1,0 +1,33 @@
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
+
+pretrained_model_dir = "meta-llama/Meta-Llama-3-8B-Instruct"
+quantized_model_dir = "Meta-Llama-3-8B-Instruct-FP8"
+
+tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
+
+DATASET_ID = "mgoin/ultrachat_2k"
+DATASET_SPLIT = "train_sft"
+ds = load_dataset(DATASET_ID, split=DATASET_SPLIT)
+ds = ds.map(
+    lambda batch: {
+        "text": tokenizer.apply_chat_template(batch["messages"], tokenize=False)
+    }
+)
+examples = [sample["text"] for sample in ds]
+tokenizer.pad_token = tokenizer.eos_token
+examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to(
+    "cuda"
+)
+
+quantize_config = BaseQuantizeConfig(
+    quant_method="fp8", activation_scheme="static"
+)  # or "static"
+
+model = AutoFP8ForCausalLM.from_pretrained(
+    pretrained_model_dir, quantize_config=quantize_config
+)
+model.quantize(examples)
+model.save_quantized(quantized_model_dir)

--- a/examples/example_mixtral.py
+++ b/examples/example_mixtral.py
@@ -7,7 +7,9 @@ pretrained_model_dir = "mistralai/Mixtral-8x7B-Instruct-v0.1"
 quantized_model_dir = "Mixtral-8x7B-Instruct-v0.1-FP8"
 
 tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
-ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(10)
+tokenizer.pad_token = tokenizer.eos_token
+
+ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(range(10))
 examples = [tokenizer.apply_chat_template(batch["messages"], tokenize=False) for batch in ds]
 examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to("cuda")
 

--- a/examples/example_mixtral.py
+++ b/examples/example_mixtral.py
@@ -3,15 +3,19 @@ from transformers import AutoTokenizer
 
 from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
-pretrained_model_dir = "meta-llama/Meta-Llama-3-8B-Instruct"
-quantized_model_dir = "Meta-Llama-3-8B-Instruct-FP8"
+pretrained_model_dir = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+quantized_model_dir = "Mixtral-8x7B-Instruct-v0.1-FP8"
 
 tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
-ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(512)
+ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(10)
 examples = [tokenizer.apply_chat_template(batch["messages"], tokenize=False) for batch in ds]
 examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to("cuda")
 
-quantize_config = BaseQuantizeConfig(quant_method="fp8", activation_scheme="static")
+quantize_config = BaseQuantizeConfig(
+    quant_method="fp8",
+    activation_scheme="static",
+    ignore_patterns=["re:.*lm_head", "re:.*gate"],
+)
 
 model = AutoFP8ForCausalLM.from_pretrained(
     pretrained_model_dir, quantize_config=quantize_config

--- a/examples/quantize.py
+++ b/examples/quantize.py
@@ -4,8 +4,8 @@ import re
 from typing import Tuple
 
 import torch
-import transformers
 import tqdm
+import transformers
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="auto_fp8",

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -1,7 +1,9 @@
 import os
-from transformers import AutoTokenizer
-from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 import shutil
+
+from transformers import AutoTokenizer
+
+from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
 
 def test_quantization():


### PR DESCRIPTION
This is needed for MoE models to skip the router layers.

Example for Mixtral:
```python
from datasets import load_dataset
from transformers import AutoTokenizer

from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig

pretrained_model_dir = "mistralai/Mixtral-8x7B-Instruct-v0.1"
quantized_model_dir = "Mixtral-8x7B-Instruct-v0.1-FP8"

tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
tokenizer.pad_token = tokenizer.eos_token

ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(range(10))
examples = [tokenizer.apply_chat_template(batch["messages"], tokenize=False) for batch in ds]
examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to("cuda")

quantize_config = BaseQuantizeConfig(
    quant_method="fp8",
    activation_scheme="static",
    ignore_patterns=["re:.*lm_head", "re:.*gate"],
)

model = AutoFP8ForCausalLM.from_pretrained(
    pretrained_model_dir, quantize_config=quantize_config
)
model.quantize(examples)
model.save_quantized(quantized_model_dir)
```

```
MixtralForCausalLM(
  (model): MixtralModel(
    (embed_tokens): Embedding(32000, 4096)
    (layers): ModuleList(
      (0-31): 32 x MixtralDecoderLayer(
        (self_attn): MixtralSdpaAttention(
          (q_proj): FP8StaticLinear()
          (k_proj): FP8StaticLinear()
          (v_proj): FP8StaticLinear()
          (o_proj): FP8StaticLinear()
          (rotary_emb): MixtralRotaryEmbedding()
        )
        (block_sparse_moe): MixtralSparseMoeBlock(
          (gate): Linear(in_features=4096, out_features=8, bias=False)
          (experts): ModuleList(
            (0-7): 8 x MixtralBlockSparseTop2MLP(
              (w1): FP8StaticLinear()
              (w2): FP8StaticLinear()
              (w3): FP8StaticLinear()
              (act_fn): SiLU()
            )
          )
        )
        (input_layernorm): MixtralRMSNorm()
        (post_attention_layernorm): MixtralRMSNorm()
      )
    )
    (norm): MixtralRMSNorm()
  )
  (lm_head): Linear(in_features=4096, out_features=32000, bias=False)
)

```