### PR TITLE
Fix passing torch_dtype and device_map via model_init_kwargs

### DIFF
--- a/auto_fp8/modeling.py
+++ b/auto_fp8/modeling.py
@@ -71,10 +71,10 @@ class AutoFP8ForCausalLM:
         torch.cuda.empty_cache()
 
         # Important defaults
-        if not hasattr(model_init_kwargs, "torch_dtype"):
+        if not "torch_dtype" in model_init_kwargs:
             model_init_kwargs["torch_dtype"] = "auto"
 
-        if not hasattr(model_init_kwargs, "device_map"):
+        if not "device_map" in model_init_kwargs:
             model_init_kwargs["device_map"] = "auto"
 
         merged_kwargs = {**model_init_kwargs, **cached_file_kwargs}

--- a/auto_fp8/modeling.py
+++ b/auto_fp8/modeling.py
@@ -71,10 +71,10 @@ class AutoFP8ForCausalLM:
         torch.cuda.empty_cache()
 
         # Important defaults
-        if not "torch_dtype" in model_init_kwargs:
+        if "torch_dtype" not in model_init_kwargs:
             model_init_kwargs["torch_dtype"] = "auto"
 
-        if not "device_map" in model_init_kwargs:
+        if "device_map" not in model_init_kwargs:
             model_init_kwargs["device_map"] = "auto"
 
         merged_kwargs = {**model_init_kwargs, **cached_file_kwargs}


### PR DESCRIPTION
Encountered a small issue when trying to convert some weights that were stored on disk in float32. I tried to pass `torch_dtype` like this:
```python
model = AutoFP8ForCausalLM.from_pretrained(
    pretrained_model_dir, quantize_config=quantize_config, torch_dtype=torch.float16
)
```
but found it wasn't getting propagated down. It is caused by a bug where are calling `getattr` on a dictionary rather than properly checking whether `torch_dtype` is a key in the dictionary. 