### PR TITLE
Improve memory usage by properly cleaning up weights as quantized

### DIFF
--- a/auto_fp8/quantize.py
+++ b/auto_fp8/quantize.py
@@ -202,11 +202,14 @@ def quantize_weights(
             or name in quantize_config.ignored_layers
         ):
             continue
-        quant_weight, quant_scale = per_tensor_quantize(linear.weight)
-        quant_linear = FP8DynamicLinear(quant_weight, quant_scale, linear.bias)
+        quant_weight, quant_scale = per_tensor_quantize(linear.weight.clone())
+        bias = linear.bias.clone() if linear.bias is not None else None
+        quant_linear = FP8DynamicLinear(quant_weight, quant_scale, bias)
         replace_module(model, name, quant_linear)
+        del linear.weight
+        del linear.bias
         del linear
-        cleanup_memory()
+    cleanup_memory()
 
 
 def quantize_activations(


### PR DESCRIPTION
Before this PR, we would run out of memory quantizing the weights of Llama 3 70B on two H100 80GB GPUs.

This is because as we were quantizing the weights, we were holding references to the original Linear modules such that PyTorch wouldn't free everything. Now we explicitly clone the weights and biases to then delete all of the original Parameters, as we quantize each module. This seems to massively improve peak memory usage and essentially makes it not an issue beyond the initial unquantized checkpoint load.