### PR TITLE
Support calibrating kv cache scales

### DIFF
--- a/auto_fp8/config.py
+++ b/auto_fp8/config.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional, Tuple
 
 
 class BaseQuantizeConfig:
@@ -17,13 +17,17 @@ class BaseQuantizeConfig:
             regex style matching i.e. re.search(), for each Linear layer.
             By default, "re:.*lm_head" is included to ignore the embedding
             Linear layer usually at the end of decoder LLMs
+        kv_cache_quant_targets: Tuple of Linear module names to target for
+            calibration of the output scales for KV cache quantization.
+            Usually, these should be `("k_proj", "v_proj")`.
     """
 
     def __init__(
         self,
         quant_method: str = "fp8",
         activation_scheme: str = "static",
-        ignore_patterns: List[str] = [],
+        ignore_patterns: List[str] = ["re:.*lm_head"],
+        kv_cache_quant_targets: Optional[Tuple[str]] = None,
     ):
         if quant_method != "fp8":
             raise ValueError("Only FP8 quantization is supported.")
@@ -34,4 +38,5 @@ class BaseQuantizeConfig:
         self.quant_method = quant_method
         self.activation_scheme = activation_scheme
         self.ignore_patterns = ignore_patterns
+        self.kv_cache_quant_targets = kv_cache_quant_targets
         self.ignored_layers = []

--- a/auto_fp8/modeling.py
+++ b/auto_fp8/modeling.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 import torch
 from transformers import AutoModelForCausalLM
@@ -26,6 +26,16 @@ class AutoFP8ForCausalLM:
         quantize_config.ignored_layers = get_layers_to_ignore(
             self.model, quantize_config.ignore_patterns
         )
+
+        if quantize_config.kv_cache_quant_targets:
+            kv_cache_quant_layers = get_kv_cache_quant_layer(
+                self.model, quantize_config.kv_cache_quant_targets
+            )
+            if len(kv_cache_quant_layers) == 0:
+                raise ValueError(
+                    f"Could not find any kv cache layers using kv_cache_quant_targets={quantize_config.kv_cache_quant_targets}, please fix your argument."
+                )
+            quantize_config.kv_cache_quant_layers = kv_cache_quant_layers
 
         self.quantize_config = quantize_config
 
@@ -97,7 +107,7 @@ class AutoFP8ForCausalLM:
 
         return cls(model, quantize_config)
 
-    def quantize(self, calibration_tokens):
+    def quantize(self, calibration_tokens: Optional[torch.Tensor] = None):
         def _prepare_calibration_data(calibration_tokens):
             if hasattr(calibration_tokens, "input_ids"):
                 return calibration_tokens.input_ids
@@ -107,6 +117,9 @@ class AutoFP8ForCausalLM:
         quantize_weights(self.model, self.quantize_config)
 
         if self.quantize_config.activation_scheme == "static":
+            assert (
+                calibration_tokens is not None
+            ), "Calibration tokens required for activation quantization"
             quantize_activations(
                 self.model,
                 self.quantize_config,
@@ -128,9 +141,6 @@ class AutoFP8ForCausalLM:
 def get_layers_to_ignore(model, ignore_patterns) -> List[str]:
     ignored_layers = set()
 
-    # TODO: don't always ignore lm_head
-    ignore_patterns.append("re:.*lm_head")
-
     for name, linear in model.named_modules():
         if not isinstance(linear, torch.nn.Linear):
             continue
@@ -148,3 +158,17 @@ def get_layers_to_ignore(model, ignore_patterns) -> List[str]:
                     ignored_layers.add(name)
 
     return list(ignored_layers)
+
+
+def get_kv_cache_quant_layer(model, kv_cache_quant_targets: Tuple[str]) -> List[str]:
+    kv_cache_quant_layers = set()
+
+    for name, linear in model.named_modules():
+        if not isinstance(linear, torch.nn.Linear):
+            continue
+
+        for output_quant_target in kv_cache_quant_targets:
+            if name.endswith(output_quant_target):
+                kv_cache_quant_layers.add(name)
+
+    return list(kv_cache_quant_layers)

--- a/auto_fp8/modeling.py
+++ b/auto_fp8/modeling.py
@@ -28,7 +28,7 @@ class AutoFP8ForCausalLM:
         )
 
         if quantize_config.kv_cache_quant_targets:
-            kv_cache_quant_layers = get_kv_cache_quant_layer(
+            kv_cache_quant_layers = get_kv_cache_quant_layers(
                 self.model, quantize_config.kv_cache_quant_targets
             )
             if len(kv_cache_quant_layers) == 0:
@@ -159,8 +159,8 @@ def get_layers_to_ignore(model, ignore_patterns) -> List[str]:
     return list(ignored_layers)
 
 
-def get_kv_cache_quant_layer(model, kv_cache_quant_targets: Tuple[str]) -> List[str]:
-    kv_cache_quant_layers = set()
+def get_kv_cache_quant_layers(model, kv_cache_quant_targets: Tuple[str]) -> List[str]:
+    kv_cache_quant_layers = []
 
     for name, linear in model.named_modules():
         if not isinstance(linear, torch.nn.Linear):
@@ -168,6 +168,6 @@ def get_kv_cache_quant_layer(model, kv_cache_quant_targets: Tuple[str]) -> List[
 
         for output_quant_target in kv_cache_quant_targets:
             if name.endswith(output_quant_target):
-                kv_cache_quant_layers.add(name)
+                kv_cache_quant_layers.append(name)
 
-    return list(kv_cache_quant_layers)
+    return kv_cache_quant_layers

--- a/auto_fp8/quantize.py
+++ b/auto_fp8/quantize.py
@@ -72,11 +72,11 @@ def fp8_gemm(A, A_scale, B, B_scale, bias, out_dtype):
         # Deal with empty tensors (triggeted by empty MoE experts)
         return torch.empty(size=(0, B.shape[0]), dtype=out_dtype, device=A.device)
 
-    native_fp8_support = (
-        torch.cuda.is_available()
-        and torch.cuda.get_device_capability() >= (8, 9)
-        and False
-    )
+    # TODO: Disable native fp8 gemm for now, always just dequantize
+    # native_fp8_support = (
+    #     torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)
+    # )
+    native_fp8_support = False
     if native_fp8_support:
         need_reshape = A.dim() == 3
         if need_reshape:

--- a/examples/example_static_kvcache.py
+++ b/examples/example_static_kvcache.py
@@ -1,0 +1,25 @@
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
+
+pretrained_model_dir = "meta-llama/Meta-Llama-3-8B-Instruct"
+quantized_model_dir = "Meta-Llama-3-8B-Instruct-FP8-KV"
+
+tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
+tokenizer.pad_token = tokenizer.eos_token
+
+ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(range(512))
+examples = [tokenizer.apply_chat_template(batch["messages"], tokenize=False) for batch in ds]
+examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to("cuda")
+
+quantize_config = BaseQuantizeConfig(
+    quant_method="fp8",
+    activation_scheme="static",
+    ignore_patterns=["re:.*lm_head"],
+    kv_cache_quant_targets=("k_proj", "v_proj"),
+)
+
+model = AutoFP8ForCausalLM.from_pretrained(pretrained_model_dir, quantize_config)
+model.quantize(examples)
+model.save_quantized(quantized_model_dir)

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -30,7 +30,7 @@ def test_dynamic_quantization(model_id, target_size):
     model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")
     shutil.rmtree(quantized_model_dir)
 
-    # We expect the model to be a certain size
+    # We expect the quantized model to be a certain size
     target_size = target_size * (1024 * 1024)
     assert model_size < target_size
 
@@ -55,7 +55,7 @@ def test_static_quantization(model_id, target_size):
     model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")
     shutil.rmtree(quantized_model_dir)
 
-    # We expect the model to be < 160MB
+    # We expect the quantized model to be a certain size
     target_size = target_size * (1024 * 1024)
     assert model_size < target_size
 
@@ -81,18 +81,18 @@ def test_kv_cache_static_quantization(model_id, target_size):
 
     tensors = safetensors.torch.load_file(f"{quantized_model_dir}/model.safetensors")
     proj_linear_count = 0
-    output_scale_count = 0
+    kv_scale_count = 0
     for name, _ in tensors.items():
         if name.endswith("k_proj.weight") or name.endswith("v_proj.weight"):
             proj_linear_count += 1
-        if name.endswith("k_proj.output_scale") or name.endswith("v_proj.output_scale"):
-            output_scale_count += 1
-    assert proj_linear_count == output_scale_count
+        if name.endswith("kv_scale"):
+            kv_scale_count += 1
+    assert proj_linear_count // 2 == kv_scale_count
 
     # Measure checkpoint size and cleanup
     model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")
     shutil.rmtree(quantized_model_dir)
 
-    # We expect the model to be < 160MB
+    # We expect the quantized model to be a certain size
     target_size = target_size * (1024 * 1024)
     assert model_size < target_size

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -1,15 +1,20 @@
 import os
 import shutil
 
+import pytest
 import safetensors.torch
 from transformers import AutoTokenizer
 
 from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
+MODELS = [
+    "facebook/opt-125m",
+    "Qwen/Qwen2-0.5B-Instruct",
+]
 
-def test_dynamic_quantization():
-    model_id = "facebook/opt-125m"
-    quantized_model_dir = "opt-125m-fp8-dynamic"
+@pytest.mark.parametrize("model_id", MODELS)
+def test_dynamic_quantization(model_id):
+    quantized_model_dir = model_id.split("/")[-1] + "-fp8-dynamic"
 
     quantize_config = BaseQuantizeConfig(
         quant_method="fp8", activation_scheme="dynamic"
@@ -30,9 +35,9 @@ def test_dynamic_quantization():
     assert model_size < target_size
 
 
-def test_static_quantization():
-    model_id = "facebook/opt-125m"
-    quantized_model_dir = "opt-125m-fp8-static"
+@pytest.mark.parametrize("model_id", MODELS)
+def test_static_quantization(model_id):
+    quantized_model_dir = model_id.split("/")[-1] + "-fp8-static"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
     examples = ["auto-fp8 is an easy-to-use model quantization library"]
@@ -54,10 +59,9 @@ def test_static_quantization():
     target_size = 160 * (1024 * 1024)
     assert model_size < target_size
 
-
-def test_kv_cache_static_quantization():
-    model_id = "facebook/opt-125m"
-    quantized_model_dir = "opt-125m-fp8-static-kv"
+@pytest.mark.parametrize("model_id", MODELS)
+def test_kv_cache_static_quantization(model_id):
+    quantized_model_dir = model_id.split("/")[-1] + "-fp8-static-kv"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
     examples = ["auto-fp8 is an easy-to-use model quantization library"]

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -8,12 +8,12 @@ from transformers import AutoTokenizer
 from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
 MODELS = [
-    "facebook/opt-125m",
-    "Qwen/Qwen2-0.5B-Instruct",
+    ("facebook/opt-125m", 160),
+    ("Qwen/Qwen2-0.5B-Instruct", 600),
 ]
 
-@pytest.mark.parametrize("model_id", MODELS)
-def test_dynamic_quantization(model_id):
+@pytest.mark.parametrize("model_id,target_size", MODELS)
+def test_dynamic_quantization(model_id, target_size):
     quantized_model_dir = model_id.split("/")[-1] + "-fp8-dynamic"
 
     quantize_config = BaseQuantizeConfig(
@@ -30,13 +30,13 @@ def test_dynamic_quantization(model_id):
     model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")
     shutil.rmtree(quantized_model_dir)
 
-    # We expect the model to be < 160MB
-    target_size = 160 * (1024 * 1024)
+    # We expect the model to be a certain size
+    target_size = target_size * (1024 * 1024)
     assert model_size < target_size
 
 
-@pytest.mark.parametrize("model_id", MODELS)
-def test_static_quantization(model_id):
+@pytest.mark.parametrize("model_id,target_size", MODELS)
+def test_static_quantization(model_id, target_size):
     quantized_model_dir = model_id.split("/")[-1] + "-fp8-static"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
@@ -56,11 +56,11 @@ def test_static_quantization(model_id):
     shutil.rmtree(quantized_model_dir)
 
     # We expect the model to be < 160MB
-    target_size = 160 * (1024 * 1024)
+    target_size = target_size * (1024 * 1024)
     assert model_size < target_size
 
-@pytest.mark.parametrize("model_id", MODELS)
-def test_kv_cache_static_quantization(model_id):
+@pytest.mark.parametrize("model_id,target_size", MODELS)
+def test_kv_cache_static_quantization(model_id, target_size):
     quantized_model_dir = model_id.split("/")[-1] + "-fp8-static-kv"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
@@ -94,5 +94,5 @@ def test_kv_cache_static_quantization(model_id):
     shutil.rmtree(quantized_model_dir)
 
     # We expect the model to be < 160MB
-    target_size = 160 * (1024 * 1024)
+    target_size = target_size * (1024 * 1024)
     assert model_size < target_size

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -1,14 +1,38 @@
 import os
 import shutil
 
+import safetensors.torch
 from transformers import AutoTokenizer
 
 from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
 
-def test_quantization():
+def test_dynamic_quantization():
     model_id = "facebook/opt-125m"
-    quantized_model_dir = "opt-125m-fp8"
+    quantized_model_dir = "opt-125m-fp8-dynamic"
+
+    quantize_config = BaseQuantizeConfig(
+        quant_method="fp8", activation_scheme="dynamic"
+    )
+
+    model = AutoFP8ForCausalLM.from_pretrained(model_id, quantize_config)
+    model.model.to("cpu")
+
+    model.quantize()
+    model.save_quantized(quantized_model_dir)
+
+    # Measure checkpoint size and cleanup
+    model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")
+    shutil.rmtree(quantized_model_dir)
+
+    # We expect the model to be < 160MB
+    target_size = 160 * (1024 * 1024)
+    assert model_size < target_size
+
+
+def test_static_quantization():
+    model_id = "facebook/opt-125m"
+    quantized_model_dir = "opt-125m-fp8-static"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
     examples = ["auto-fp8 is an easy-to-use model quantization library"]
@@ -16,13 +40,47 @@ def test_quantization():
 
     quantize_config = BaseQuantizeConfig(quant_method="fp8", activation_scheme="static")
 
-    model = AutoFP8ForCausalLM.from_pretrained(
-        model_id, quantize_config=quantize_config
-    )
+    model = AutoFP8ForCausalLM.from_pretrained(model_id, quantize_config)
     model.model.to("cpu")
 
     model.quantize(examples)
     model.save_quantized(quantized_model_dir)
+
+    # Measure checkpoint size and cleanup
+    model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")
+    shutil.rmtree(quantized_model_dir)
+
+    # We expect the model to be < 160MB
+    target_size = 160 * (1024 * 1024)
+    assert model_size < target_size
+
+
+def test_kv_cache_static_quantization():
+    model_id = "facebook/opt-125m"
+    quantized_model_dir = "opt-125m-fp8-static-kv"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
+    examples = ["auto-fp8 is an easy-to-use model quantization library"]
+    examples = tokenizer(examples, return_tensors="pt")
+
+    quantize_config = BaseQuantizeConfig(
+        quant_method="fp8",
+        activation_scheme="static",
+        kv_cache_quant_targets=("k_proj", "v_proj"),
+    )
+
+    model = AutoFP8ForCausalLM.from_pretrained(model_id, quantize_config)
+    model.model.to("cpu")
+
+    model.quantize(examples)
+    model.save_quantized(quantized_model_dir)
+
+    tensors = safetensors.torch.load_file(f"{quantized_model_dir}/model.safetensors")
+    count_matches = 0
+    for name, tensor in tensors.items():
+        if name.endswith("k_proj.output_scale") or name.endswith("v_proj.output_scale"):
+            count_matches += 1
+    assert count_matches == 24
 
     # Measure checkpoint size and cleanup
     model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -9,7 +9,7 @@ from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig
 
 MODELS = [
     ("facebook/opt-125m", 160),
-    ("Qwen/Qwen2-0.5B-Instruct", 600),
+    ("Qwen/Qwen2-0.5B-Instruct", 620),
 ]
 
 @pytest.mark.parametrize("model_id,target_size", MODELS)
@@ -83,7 +83,7 @@ def test_kv_cache_static_quantization(model_id, target_size):
     proj_linear_count = 0
     output_scale_count = 0
     for name, _ in tensors.items():
-        if name.endswith("k_proj") or name.endswith("v_proj"):
+        if name.endswith("k_proj.weight") or name.endswith("v_proj.weight"):
             proj_linear_count += 1
         if name.endswith("k_proj.output_scale") or name.endswith("v_proj.output_scale"):
             output_scale_count += 1

--- a/tests/test_auto_fp8.py
+++ b/tests/test_auto_fp8.py
@@ -80,11 +80,14 @@ def test_kv_cache_static_quantization(model_id):
     model.save_quantized(quantized_model_dir)
 
     tensors = safetensors.torch.load_file(f"{quantized_model_dir}/model.safetensors")
-    count_matches = 0
-    for name, tensor in tensors.items():
+    proj_linear_count = 0
+    output_scale_count = 0
+    for name, _ in tensors.items():
+        if name.endswith("k_proj") or name.endswith("v_proj"):
+            proj_linear_count += 1
         if name.endswith("k_proj.output_scale") or name.endswith("v_proj.output_scale"):
-            count_matches += 1
-    assert count_matches == 24
+            output_scale_count += 1
+    assert proj_linear_count == output_scale_count
 
     # Measure checkpoint size and cleanup
     model_size = os.path.getsize(f"{quantized_model_dir}/model.safetensors")


### PR DESCRIPTION
Adds a `kv_cache_quant_targets` quant config argument that attaches `output_scales` to the specified Linear modules. This means we will end up with `k_proj.output_scale` and `v_proj.output_scale` after activation calibration. For the final checkpoint, we add a pass to take the maximum of `k_proj.output_scale` and `v_proj.output_scale`, and place the result in the parent of those modules (the Attention module) as a single `kv_scale`, which is needed to match the representation in vLLM.

Also includes a decent chunk of refactoring to allow for no examples to be passed in for weight quantization, renaming for clearer understanding of modules, making `"re:.*lm_head"` not a required ignored pattern but just a default, and disabling torch._scaled_mm for easier usage on CPU.

A new example is included to show how to enable this functionality
```python
from datasets import load_dataset
from transformers import AutoTokenizer

from auto_fp8 import AutoFP8ForCausalLM, BaseQuantizeConfig

pretrained_model_dir = "meta-llama/Meta-Llama-3-8B-Instruct"
quantized_model_dir = "Meta-Llama-3-8B-Instruct-FP8-KV"

tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
tokenizer.pad_token = tokenizer.eos_token

ds = load_dataset("mgoin/ultrachat_2k", split="train_sft").select(range(512))
examples = [tokenizer.apply_chat_template(batch["messages"], tokenize=False) for batch in ds]
examples = tokenizer(examples, padding=True, truncation=True, return_tensors="pt").to("cuda")

quantize_config = BaseQuantizeConfig(
    quant_method="fp8",
    activation_scheme="static",
    ignore_patterns=["re:.*lm_head"],
    kv_cache_quant_targets=("k_proj", "v_proj"),
)

model = AutoFP8ForCausalLM.from_pretrained(pretrained_model_dir, quantize_config)
model.quantize(examples)
model.save_quantized(quantized_model_dir)
```